### PR TITLE
Fix incorrect carry computation in SBC instruction

### DIFF
--- a/mc6809.c
+++ b/mc6809.c
@@ -3230,7 +3230,7 @@ static mc6809byte__t op_sbc(
   ci        = res ^ dest ^ src;
   cpu->cc.n = (res >  0x7F);
   cpu->cc.z = (res == 0x00);
-  cpu->cc.c = src >= dest;
+  cpu->cc.c = src + cpu->cc.c > dest;
   cpu->cc.v  = ((ci & 0x80) != 0) ^ cpu->cc.c;
   return res;
 }

--- a/mc6809.c
+++ b/mc6809.c
@@ -3323,7 +3323,7 @@ static mc6809byte__t op_adc(
   cpu->cc.h = (ci  &  0x10);
   cpu->cc.n = (res >  0x7F);
   cpu->cc.z = (res == 0x00);
-  cpu->cc.c = (res < dest) || (res < src);
+  cpu->cc.c = (res < dest + cpu->cc.c);
   cpu->cc.v  = ((ci & 0x80) != 0) ^ cpu->cc.c;
   return res;
 }
@@ -3365,7 +3365,7 @@ static mc6809byte__t op_add(
   cpu->cc.h = (ci  &  0x10);
   cpu->cc.n = (res >  0x7F);
   cpu->cc.z = (res == 0x00);
-  cpu->cc.c = (res < dest) || (res < src);
+  cpu->cc.c = (res < dest);
   cpu->cc.v  = ((ci & 0x80) != 0) ^ cpu->cc.c;
   return res;
 }


### PR DESCRIPTION
I found a bug which prevented Grant Searle's 6809 extended BASIC running properly, it was computing wrong values in the math routines. It turned out to be incorrect carry from the SBC.

If interested you can see my hacked-on version that can run the BASIC and which contains some tracing to isolate the bug in the `master` branch of my fork: https://github.com/nickd4/mc6809.git